### PR TITLE
Upgrade to native_assets_cli 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.1.0
+## 0.2.1
+
+* Bump native_assets_cli to 0.10.0.
+
+## 0.2.0
 
 * Add `buildShaderBundleJson` build hook utility.
 * Document usage instructions in the readme.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,4 @@
-## 0.2.1
-
-* Bump native_assets_cli to 0.10.0.
-
-## 0.2.0
+## 0.1.0
 
 * Add `buildShaderBundleJson` build hook utility.
 * Document usage instructions in the readme.
@@ -28,3 +24,7 @@
 
 * Update to native_assets_cli 0.9.0.
   Breaking: `BuildOutput` is now `BuildOutputBuilder`
+
+## 0.2.1
+
+* Bump native_assets_cli to 0.10.0.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,18 @@
 name: flutter_gpu_shaders
-description: "Build tools for Flutter GPU shader bundles/libraries."
+description: 'Build tools for Flutter GPU shader bundles/libraries.'
 version: 0.2.0
 homepage: https://github.com/bdero/flutter_gpu_shaders
 
 environment:
   sdk: ^3.4.0
-  flutter: ">=1.17.0"
+  flutter: '>=1.17.0'
 
 dependencies:
   flutter:
     sdk: flutter
   logging: ^1.2.0
   # https://github.com/bdero/flutter_gpu_shaders/issues/3
-  native_assets_cli: '>=0.9.0 <0.10.0'
+  native_assets_cli: '>=0.10.0 <0.11.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Context:

* https://github.com/bdero/flutter_scene/issues/48

(Completely unrelated side note: Consider using `package:mono_repo` to group multiple related packages together in a git repo. And benefit from pub workspaces to avoid ping-ponging between path dependencies and published dependencies.)