### PR TITLE
modify README.md of buildShaderBundleJson

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Use native asset build hooks to import Flutter GPU shader bundle assets.
     void main(List<String> args) async {
       await build(args, (config, output) async {
         await buildShaderBundleJson(
-            buildConfig: config,
+            buildInput: config,
             buildOutput: output,
             manifestFileName: 'my_cool_bundle.shaderbundle.json');
       });


### PR DESCRIPTION
`buildShaderBundleJson` does not match the API and can cause confusion...

change from `buildConfig: config,` to `buildInput: config`