### PR TITLE
Migrate from native_assets_cli to hooks 1.0 (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,10 @@
 * Update to native_assets_cli to 0.13.0.
   (https://github.com/bdero/flutter_gpu_shaders/issues/6)
   Breaking: `BuildConfig` is now `BuildInput`
+
+## 0.4.0
+
+* Migrate from `native_assets_cli` (discontinued) to `hooks` 1.0. Build
+  hook authors must now `import 'package:hooks/hooks.dart';` instead of
+  `package:native_assets_cli/native_assets_cli.dart`.
+* Bump SDK constraint to `^3.7.0` (matches `hooks` 1.0 requirements).

--- a/lib/build.dart
+++ b/lib/build.dart
@@ -3,8 +3,7 @@ library flutter_gpu_shaders;
 import 'dart:convert' as convert;
 import 'dart:io';
 
-import 'package:native_assets_cli/code_assets_testing.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:hooks/hooks.dart';
 
 import 'package:flutter_gpu_shaders/environment.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,17 @@
 name: flutter_gpu_shaders
 description: 'Build tools for Flutter GPU shader bundles/libraries.'
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/bdero/flutter_gpu_shaders
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.7.0
   flutter: '>=1.17.0'
 
 dependencies:
   flutter:
     sdk: flutter
+  hooks: ^1.0.0
   logging: ^1.2.0
-  # https://github.com/bdero/flutter_gpu_shaders/issues/3
-  native_assets_cli: '>=0.13.0 <0.14.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

The `native_assets_cli` package is discontinued in favor of `hooks`. This is a small but breaking change for consumers — build hook authors must now `import 'package:hooks/hooks.dart'` instead of `package:native_assets_cli/native_assets_cli.dart`. The API surface used here (`build()`, `BuildInput`, `BuildOutputBuilder`) carries over without changes.

## Changes

- `lib/build.dart`:
  - Drop the unused `package:native_assets_cli/code_assets_testing.dart` import (it was the only `code_assets_testing` reference in the codebase — leftover).
  - Swap `package:native_assets_cli/native_assets_cli.dart` → `package:hooks/hooks.dart`.
- `pubspec.yaml`:
  - `native_assets_cli '>=0.13.0 <0.14.0'` → `hooks: ^1.0.0`
  - Bump SDK constraint to `^3.7.0` (matches `hooks` 1.0).
  - Bump version `0.3.0 → 0.4.0` (breaking change for consumers).
- `CHANGELOG.md`: 0.4.0 entry.

## Why now

The downstream `flutter_scene` repo's example app fails to build on Dart 3.10+ because `native_assets_cli` ships an `--enable-experiment=native-assets` flag that's now rejected (the experiment graduated). Migrating both repos to `hooks` fixes the issue at the right layer.

## Test plan

- [x] `dart analyze` clean
- [x] `flutter test` passes (2 tests)
- [x] `flutter pub publish --dry-run` clean (4 KB archive, 0 warnings)
- [x] Smoke-tested end-to-end as a path: dep from flutter_scene's example app — builds and runs with Impeller