### PR TITLE
Track shader source files as build hook dependencies (0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.4.3
+
+* `buildShaderBundleJson` now declares the manifest and every shader
+  source file it references as build-hook dependencies. The build
+  system reruns the hook (and `impellerc`) whenever any of those
+  inputs change, so editing a `.frag` no longer requires a manual
+  clean. Transitive `#include`s aren't tracked yet because
+  `impellerc`'s `--depfile` switch is a no-op when `--shader-bundle`
+  is in use; this is a known limitation pending an upstream fix.
+* New `collectShaderBundleDependencies(manifestUri, decodedManifest)`
+  helper returns the dependency set for inspection from custom build
+  hooks and tests.
+
 ## 0.1.0
 
 * Add `buildShaderBundleJson` build hook utility.

--- a/lib/build.dart
+++ b/lib/build.dart
@@ -12,6 +12,7 @@ Future<void> _buildShaderBundleJson({
   required Uri packageRoot,
   required Uri inputManifestFilePath,
   required Uri outputBundleFilePath,
+  required BuildOutputBuilder buildOutput,
 }) async {
   /////////////////////////////////////////////////////////////////////////////
   /// 1. Parse the manifest file.
@@ -22,10 +23,26 @@ Future<void> _buildShaderBundleJson({
   final decodedManifest = convert.json.decode(manifest);
   String reconstitutedManifest = convert.json.encode(decodedManifest);
 
-  //throw Exception(reconstitutedManifest);
+  /////////////////////////////////////////////////////////////////////////////
+  /// 2. Declare build-system dependencies.
+  ///
+  /// The build hook needs to rerun when any input that influences the
+  /// produced shader bundle changes. We track the manifest itself and
+  /// every shader source file it references. The build hook framework
+  /// reruns this hook the next time any listed dependency's mtime
+  /// changes.
+  ///
+  /// Transitive `#include`s aren't tracked yet. `impellerc`'s
+  /// `--depfile` switch (which would let us capture them) is a no-op
+  /// in `--shader-bundle` mode today; that's filed as an upstream
+  /// follow-up.
+
+  buildOutput.dependencies.addAll(
+    collectShaderBundleDependencies(inputManifestFilePath, decodedManifest),
+  );
 
   /////////////////////////////////////////////////////////////////////////////
-  /// 2. Build the shader bundle.
+  /// 3. Build the shader bundle.
   ///
 
   final impellercExec = await findImpellerC();
@@ -49,6 +66,34 @@ Future<void> _buildShaderBundleJson({
   }
 }
 
+/// Collects the build-system dependencies declared by a shader bundle
+/// manifest.
+///
+/// Returns the manifest URI itself plus the resolved URI of every
+/// shader source file referenced by a top-level entry's `file` key.
+/// Paths in the manifest are interpreted relative to the manifest's
+/// containing directory.
+///
+/// Exposed so users authoring custom build hooks (and tests) can
+/// inspect the same dependency set [buildShaderBundleJson] declares.
+List<Uri> collectShaderBundleDependencies(
+  Uri manifestUri,
+  Object decodedManifest,
+) {
+  final manifestDir = manifestUri.resolve('./');
+  final result = <Uri>[manifestUri];
+  if (decodedManifest is! Map) {
+    return result;
+  }
+  for (final value in decodedManifest.values) {
+    if (value is! Map) continue;
+    final file = value['file'];
+    if (file is! String) continue;
+    result.add(manifestDir.resolve(file));
+  }
+  return result;
+}
+
 /// Build a Flutter GPU shader bundle/library from a JSON manifest file.
 ///
 /// The [buildInput] and [buildOutput] are provided by the build hook system.
@@ -61,6 +106,10 @@ Future<void> _buildShaderBundleJson({
 /// The built shader bundle will be written to
 /// `build/shaderbundles/[name].shaderbundle`,
 /// relative to the package root where the build hook resides.
+///
+/// The hook declares the manifest and every shader source file it
+/// references as build-system dependencies, so the bundle is rebuilt
+/// when any input changes.
 ///
 /// Example usage:
 ///
@@ -128,5 +177,6 @@ Future<void> buildShaderBundleJson({
     packageRoot: packageRoot,
     inputManifestFilePath: inFile,
     outputBundleFilePath: outFile,
+    buildOutput: buildOutput,
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gpu_shaders
 description: 'Build tools for Flutter GPU shader bundles/libraries.'
-version: 0.4.2
+version: 0.4.3
 homepage: https://github.com/bdero/flutter_gpu_shaders
 
 environment:

--- a/test/build_test.dart
+++ b/test/build_test.dart
@@ -1,0 +1,73 @@
+import 'dart:convert' as convert;
+
+import 'package:flutter_gpu_shaders/build.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('collectShaderBundleDependencies', () {
+    test('returns the manifest plus each referenced shader file', () {
+      final manifestUri = Uri.parse(
+        'file:///pkg/shaders/bundle.shaderbundle.json',
+      );
+      final manifest = convert.json.decode('''
+        {
+          "UnskinnedVertex": {
+            "type": "vertex",
+            "file": "flutter_scene_unskinned.vert"
+          },
+          "StandardFragment": {
+            "type": "fragment",
+            "file": "flutter_scene_standard.frag"
+          }
+        }
+      ''');
+      final deps = collectShaderBundleDependencies(manifestUri, manifest);
+      expect(deps, [
+        manifestUri,
+        Uri.parse('file:///pkg/shaders/flutter_scene_unskinned.vert'),
+        Uri.parse('file:///pkg/shaders/flutter_scene_standard.frag'),
+      ]);
+    });
+
+    test('resolves subdirectory-relative paths against the manifest dir', () {
+      final manifestUri = Uri.parse(
+        'file:///pkg/shaders/bundle.shaderbundle.json',
+      );
+      final manifest = convert.json.decode('''
+        {
+          "DeepVertex": {
+            "type": "vertex",
+            "file": "stages/vertex/deep.vert"
+          }
+        }
+      ''');
+      final deps = collectShaderBundleDependencies(manifestUri, manifest);
+      expect(deps, [
+        manifestUri,
+        Uri.parse('file:///pkg/shaders/stages/vertex/deep.vert'),
+      ]);
+    });
+
+    test('skips entries without a string file field', () {
+      final manifestUri = Uri.parse('file:///pkg/bundle.shaderbundle.json');
+      // Malformed entries should not blow up; the user will see a real
+      // error from impellerc when it tries to compile.
+      final manifest = convert.json.decode('''
+        {
+          "Good":   { "type": "vertex",   "file": "good.vert" },
+          "Bad":    { "type": "fragment" },
+          "Ugly":   "not even a map",
+          "Worse":  { "type": "vertex", "file": 42 }
+        }
+      ''');
+      final deps = collectShaderBundleDependencies(manifestUri, manifest);
+      expect(deps, [manifestUri, Uri.parse('file:///pkg/good.vert')]);
+    });
+
+    test('returns only the manifest when the decoded value is not a map', () {
+      final manifestUri = Uri.parse('file:///pkg/bundle.shaderbundle.json');
+      final deps = collectShaderBundleDependencies(manifestUri, '[]');
+      expect(deps, [manifestUri]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The `buildShaderBundleJson` build hook previously declared no dependencies. The build framework therefore only reran the hook when its own source or the manifest JSON's mtime changed; editing a `.frag` / `.vert` / `.comp` source file did **not** invalidate the cached output. End users had to run \`flutter clean\` (or the more aggressive reset recipe documented in the flutter_scene repo's CLAUDE.md trap #3) after every shader edit, which made shader iteration painful and confused new users.

This change declares the manifest and every shader source file the manifest references as build-hook dependencies via the existing \`BuildOutputBuilder.dependencies\` API. The build hook reruns the next time any tracked input's mtime changes, and \`impellerc\` recompiles the bundle. The new logic is factored into a public \`collectShaderBundleDependencies(manifestUri, decodedManifest)\` helper for callers writing custom hooks (and for unit tests).

This is also a prerequisite for the larger shader hot-reload story for Flutter GPU shader bundles. Without dependency tracking, the rest of the hot-reload plumbing (engine-side eviction, service extension, flutter_tools wiring) has nothing to react to: the build hook would never produce a fresh bundle from edited shader source.

## Known limitation

Transitive \`#include\`s aren't tracked yet. \`impellerc\`'s \`--depfile\` switch would capture them, but it's a no-op in \`--shader-bundle\` mode today: \`GenerateShaderBundle\` in \`impeller/compiler/shader_bundle.cc\` takes an early-return path before \`OutputDepfile\` is called. I'll file an upstream issue to make \`--depfile\` work with \`--shader-bundle\` so we can capture transitive deps in a follow-up. For now, editing a header that's \`#include\`d from a shader doesn't trigger a rebuild on its own; the user can touch the directly-listed shader to force one.

## Test plan

- [x] New \`test/build_test.dart\` covers \`collectShaderBundleDependencies\`:
  - Manifest plus each referenced shader file.
  - Subdirectory-relative paths resolved against the manifest dir.
  - Malformed entries (missing / non-string \`file\` field, non-map values) are skipped without throwing.
  - Non-map root value returns just the manifest.
- [x] Existing \`environment_test.dart\` still passes.
- [x] \`dart analyze\` clean.
- [x] \`dart format\` clean.
- [x] \`flutter pub publish --dry-run\` clean (the one warning is the uncommitted-changes notice; gone once this is merged).

## Version

Bumps to 0.4.3. Backward-compatible: existing call sites continue to work unchanged.