### PR TITLE
Add GitHub Actions workflow for lint + tests

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,40 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: master
+      - run: dart --version
+      - run: flutter --version
+      - name: Resolve dependencies
+        run: flutter pub get
+      - name: Lint analysis
+        run: dart analyze
+      - name: Dart format
+        run: dart format --output none --set-exit-if-changed $(find . -name '**.dart' -not -path '*/build/*')
+
+  test:
+    name: Test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: master
+      - name: Resolve dependencies
+        run: flutter pub get
+      - name: Run tests
+        run: flutter test

--- a/lib/build.dart
+++ b/lib/build.dart
@@ -37,11 +37,15 @@ Future<void> _buildShaderBundleJson({
     '--include=${shaderLibPath.toFilePath()}',
   ];
 
-  final impellerc = Process.runSync(impellercExec.toFilePath(), impellercArgs,
-      workingDirectory: packageRoot.toFilePath());
+  final impellerc = Process.runSync(
+    impellercExec.toFilePath(),
+    impellercArgs,
+    workingDirectory: packageRoot.toFilePath(),
+  );
   if (impellerc.exitCode != 0) {
     throw Exception(
-        'Failed to build shader bundle: ${impellerc.stderr}\n${impellerc.stdout}');
+      'Failed to build shader bundle: ${impellerc.stderr}\n${impellerc.stdout}',
+    );
   }
 }
 
@@ -84,18 +88,21 @@ Future<void> _buildShaderBundleJson({
 ///     }
 /// }
 /// ```
-Future<void> buildShaderBundleJson(
-    {required BuildInput buildInput,
-    required BuildOutputBuilder buildOutput,
-    required String manifestFileName}) async {
+Future<void> buildShaderBundleJson({
+  required BuildInput buildInput,
+  required BuildOutputBuilder buildOutput,
+  required String manifestFileName,
+}) async {
   String outputFileName = Uri(path: manifestFileName).pathSegments.last;
   if (!outputFileName.endsWith('.shaderbundle.json')) {
     throw Exception(
-        'Shader bundle manifest file names must end with ".shaderbundle.json".');
+      'Shader bundle manifest file names must end with ".shaderbundle.json".',
+    );
   }
   if (outputFileName.length <= '.shaderbundle.json'.length) {
     throw Exception(
-        'Invalid shader bundle manifest file name: $outputFileName');
+      'Invalid shader bundle manifest file name: $outputFileName',
+    );
   }
   if (outputFileName.endsWith('.json')) {
     outputFileName = outputFileName.substring(0, outputFileName.length - 5);
@@ -109,7 +116,8 @@ Future<void> buildShaderBundleJson(
   // flutter_tools (currently `available: true` on master, so consumers
   // would need a `flutter config --enable-dart-data-assets` step).
   final outDir = Directory.fromUri(
-      buildInput.packageRoot.resolve('build/shaderbundles/'));
+    buildInput.packageRoot.resolve('build/shaderbundles/'),
+  );
   await outDir.create(recursive: true);
   final packageRoot = buildInput.packageRoot;
 
@@ -117,7 +125,8 @@ Future<void> buildShaderBundleJson(
   final outFile = outDir.uri.resolve(outputFileName);
 
   await _buildShaderBundleJson(
-      packageRoot: packageRoot,
-      inputManifestFilePath: inFile,
-      outputBundleFilePath: outFile);
+    packageRoot: packageRoot,
+    inputManifestFilePath: inFile,
+    outputBundleFilePath: outFile,
+  );
 }

--- a/lib/environment.dart
+++ b/lib/environment.dart
@@ -30,20 +30,24 @@ Uri findEngineArtifactsDir({String? dartPath}) {
         dartExec.pathSegments[i] == 'artifacts') {
       // Note: The final empty string denotes that this is a directory path.
       cacheDir = dartExec.replace(
-          pathSegments: dartExec.pathSegments.sublist(0, i) + ['']);
+        pathSegments: dartExec.pathSegments.sublist(0, i) + [''],
+      );
       break;
     }
   }
   if (cacheDir == null) {
     throw Exception(
-        'Unable to find Flutter SDK cache directory! Dart executable: `${dartExec.toFilePath()}`');
+      'Unable to find Flutter SDK cache directory! Dart executable: `${dartExec.toFilePath()}`',
+    );
   }
   // We should now have a path of `/path/to/flutter/bin/cache/`.
 
-  final engineArtifactsDir = cacheDir
-      .resolve('./artifacts/engine/'); // Note: The final slash is important.
+  final engineArtifactsDir = cacheDir.resolve(
+    './artifacts/engine/',
+  ); // Note: The final slash is important.
   logger.info(
-      'Flutter SDK cache directory: `${engineArtifactsDir.toFilePath()}`');
+    'Flutter SDK cache directory: `${engineArtifactsDir.toFilePath()}`',
+  );
 
   return engineArtifactsDir;
 }
@@ -60,7 +64,8 @@ Future<Uri> findImpellerC() async {
     logger.info('IMPELLERC compile-time define: `$impellercDefine`');
     if (!await File(impellercDefine).exists()) {
       throw Exception(
-          'IMPELLERC compile-time define is set, but it doesn\'t point to a valid file!');
+        'IMPELLERC compile-time define is set, but it doesn\'t point to a valid file!',
+      );
     }
     return Uri.file(impellercDefine);
   }
@@ -78,7 +83,8 @@ Future<Uri> findImpellerC() async {
     logger.info('IMPELLERC environment variable: `$impellercEnvVar`');
     if (!await File(impellercEnvVar).exists()) {
       throw Exception(
-          'IMPELLERC environment variable is set, but it doesn\'t point to a valid file!');
+        'IMPELLERC environment variable is set, but it doesn\'t point to a valid file!',
+      );
     }
     return Uri.file(impellercEnvVar);
   }
@@ -105,7 +111,8 @@ Future<Uri> findImpellerC() async {
   }
   if (found == null) {
     throw Exception(
-        'Unable to find impellerc! Tried the following locations: $tried');
+      'Unable to find impellerc! Tried the following locations: $tried',
+    );
   }
 
   return found;

--- a/test/environment_test.dart
+++ b/test/environment_test.dart
@@ -11,8 +11,11 @@ void main() {
     ];
     for (String path in pathVariations) {
       Uri result = findEngineArtifactsDir(dartPath: path);
-      expect(result.pathSegments.sublist(result.pathSegments.length - 3),
-          ['artifacts', 'engine', '']);
+      expect(result.pathSegments.sublist(result.pathSegments.length - 3), [
+        'artifacts',
+        'engine',
+        '',
+      ]);
     }
   });
 


### PR DESCRIPTION
## Summary

flutter_gpu_shaders has no CI today, so issues like the depfile-tracking gap addressed in #13 (or future regressions) only surface when someone runs the tests locally. This PR adds a CI workflow mirroring the one used by flutter_scene.

The workflow has two jobs, both on \`macos-latest\` with the Flutter master channel:

- **Lint**: \`dart analyze\` over the package plus \`dart format --set-exit-if-changed\` across all Dart sources.
- **Test**: \`flutter test\` over everything under \`test/\`.

Mirrors the structure at flutter_scene's \`.github/workflows/flutter.yml\` so anyone familiar with one repo's CI recognizes the other.

## Format fixups included

The existing \`lib/build.dart\`, \`lib/environment.dart\`, and \`test/environment_test.dart\` weren't formatted to the current \`dart format\` output. To keep CI green from day one, this PR also runs format across them. Pure reformat, no semantic changes.

## Test plan

- [x] \`dart analyze\` clean locally.
- [x] \`dart format --set-exit-if-changed\` clean locally.
- [x] \`flutter test\` passes locally (the existing environment tests).
- [ ] CI passes once this PR runs through GitHub Actions.

## Followup

Once #13 (build hook dependency tracking) lands, its new \`test/build_test.dart\` will start being picked up by this workflow automatically. No additional config needed.