### PR TITLE
Update Flutter package dependencies

### DIFF
--- a/lib/base.dart
+++ b/lib/base.dart
@@ -1,5 +1,3 @@
-library flutter_gpu_shaders;
-
 import 'package:logging/logging.dart';
 
 final logger = Logger('');

--- a/lib/build.dart
+++ b/lib/build.dart
@@ -1,5 +1,3 @@
-library flutter_gpu_shaders;
-
 import 'dart:convert' as convert;
 import 'dart:io';
 
@@ -19,8 +17,9 @@ Future<void> _buildShaderBundleJson({
   /// 1. Parse the manifest file.
   ///
 
-  final manifest =
-      await File(inputManifestFilePath.toFilePath()).readAsString();
+  final manifest = await File(
+    inputManifestFilePath.toFilePath(),
+  ).readAsString();
   final decodedManifest = convert.json.decode(manifest);
   String reconstitutedManifest = convert.json.encode(decodedManifest);
 

--- a/lib/environment.dart
+++ b/lib/environment.dart
@@ -1,5 +1,3 @@
-library flutter_gpu_shaders;
-
 import 'dart:io';
 
 import 'package:flutter_gpu_shaders/base.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,18 +4,18 @@ version: 0.4.4
 homepage: https://github.com/bdero/flutter_gpu_shaders
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.10.0
   flutter: '>=1.17.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  hooks: ^1.0.0
-  logging: ^1.2.0
+  hooks: ^2.0.0
+  logging: ^1.3.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
+  flutter_lints: ^6.0.0
 
 flutter:


### PR DESCRIPTION
## Summary
- update package constraints to current latest releases for hooks, logging, and flutter_lints
- raise the Dart SDK floor to ^3.10.0 for hooks 2.0 compatibility
- remove obsolete named library declarations required by the newer lint set

## Verification
- flutter pub outdated
- dart analyze
- dart format --output none --set-exit-if-changed $(find . -name '**.dart' -not -path '*/build/*')
- flutter test
- flutter pub publish --dry-run