### PR TITLE
Add Flutter channel shader bundle smoke shards

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -38,3 +38,16 @@ jobs:
         run: flutter pub get
       - name: Run tests
         run: flutter test
+
+  shader-bundle-smoke:
+    name: Shader bundle smoke
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: master
+      - run: flutter --version
+      - name: Verify Flutter master shader bundle hook behavior
+        run: tool/verify_flutter_master.sh

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Run tests
         run: flutter test
 
-  shader-bundle-smoke:
-    name: Shader bundle smoke
+  shader-bundle-smoke-master:
+    name: Shader bundle smoke (master)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,4 +50,19 @@ jobs:
           channel: master
       - run: flutter --version
       - name: Verify Flutter master shader bundle hook behavior
-        run: tool/verify_flutter_master.sh
+        run: tool/verify_shader_bundle_hook.sh
+        env:
+          VERIFY_TRANSITIVE_INCLUDE: true
+
+  shader-bundle-smoke-stable:
+    name: Shader bundle smoke (stable)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter --version
+      - name: Verify Flutter stable shader bundle hook behavior
+        run: tool/verify_shader_bundle_hook.sh

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Verify Flutter master shader bundle hook behavior
         run: tool/verify_shader_bundle_hook.sh
         env:
+          VERIFY_BUILD_HOOK_CACHE: true
+          VERIFY_DIRECT_SHADER: true
           VERIFY_TRANSITIVE_INCLUDE: true
 
   shader-bundle-smoke-stable:
@@ -64,5 +66,5 @@ jobs:
         with:
           channel: stable
       - run: flutter --version
-      - name: Verify Flutter stable shader bundle hook behavior
+      - name: Verify Flutter stable shader bundle build compatibility
         run: tool/verify_shader_bundle_hook.sh

--- a/test_fixtures/shader_bundle_app/hook/build.dart
+++ b/test_fixtures/shader_bundle_app/hook/build.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_gpu_shaders/build.dart';
+import 'package:hooks/hooks.dart';
+
+void main(List<String> args) async {
+  await build(args, (input, output) async {
+    await buildShaderBundleJson(
+      buildInput: input,
+      buildOutput: output,
+      manifestFileName: 'test_bundle.shaderbundle.json',
+      includeDirectories: [input.packageRoot.resolve('shaders/')],
+    );
+  });
+}

--- a/test_fixtures/shader_bundle_app/lib/main.dart
+++ b/test_fixtures/shader_bundle_app/lib/main.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/widgets.dart';
+
+void main() {
+  runApp(const SizedBox.shrink());
+}

--- a/test_fixtures/shader_bundle_app/pubspec.yaml
+++ b/test_fixtures/shader_bundle_app/pubspec.yaml
@@ -1,0 +1,16 @@
+name: shader_bundle_app
+description: Fixture app for exercising flutter_gpu_shaders build hooks.
+publish_to: none
+
+environment:
+  sdk: ^3.10.0
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_gpu_shaders:
+    path: ../..
+  hooks: ^2.0.0
+
+flutter:
+  uses-material-design: true

--- a/test_fixtures/shader_bundle_app/shaders/shared_color.glsl
+++ b/test_fixtures/shader_bundle_app/shaders/shared_color.glsl
@@ -1,0 +1,3 @@
+vec4 sharedColor() {
+  return vec4(0.1, 0.2, 0.3, 1.0);
+}

--- a/test_fixtures/shader_bundle_app/shaders/smoke.frag
+++ b/test_fixtures/shader_bundle_app/shaders/smoke.frag
@@ -1,0 +1,9 @@
+#version 460 core
+
+#include <shared_color.glsl>
+
+out vec4 frag_color;
+
+void main() {
+  frag_color = sharedColor();
+}

--- a/test_fixtures/shader_bundle_app/shaders/smoke.vert
+++ b/test_fixtures/shader_bundle_app/shaders/smoke.vert
@@ -1,0 +1,7 @@
+#version 460 core
+
+in vec2 position;
+
+void main() {
+  gl_Position = vec4(position, 0.0, 1.0);
+}

--- a/test_fixtures/shader_bundle_app/test_bundle.shaderbundle.json
+++ b/test_fixtures/shader_bundle_app/test_bundle.shaderbundle.json
@@ -1,0 +1,10 @@
+{
+  "SmokeVertex": {
+    "type": "vertex",
+    "file": "shaders/smoke.vert"
+  },
+  "SmokeFragment": {
+    "type": "fragment",
+    "file": "shaders/smoke.frag"
+  }
+}

--- a/tool/verify_flutter_master.sh
+++ b/tool/verify_flutter_master.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture_source="$repo_root/test_fixtures/shader_bundle_app"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+fixture="$workdir/shader_bundle_app"
+cp -R "$fixture_source" "$fixture"
+
+cat > "$fixture/pubspec_overrides.yaml" <<YAML
+dependency_overrides:
+  flutter_gpu_shaders:
+    path: "$repo_root"
+YAML
+
+cd "$fixture"
+
+flutter --version
+flutter pub get
+
+flutter build bundle
+bundle="build/shaderbundles/test_bundle.shaderbundle"
+if [[ ! -s "$bundle" ]]; then
+  echo "Expected shader bundle at $bundle" >&2
+  exit 1
+fi
+
+second_build_log="$workdir/second_build.log"
+flutter build bundle -v > "$second_build_log" 2>&1
+if ! grep -q "Skipping target: build_hooks" "$second_build_log"; then
+  echo "Expected unchanged build to skip build_hooks." >&2
+  cat "$second_build_log" >&2
+  exit 1
+fi
+
+cat > shaders/shared_color.glsl <<'GLSL'
+vec4 sharedColor() {
+  return vec4(0.9, 0.8, 0.7, 1.0);
+}
+GLSL
+
+third_build_log="$workdir/third_build.log"
+flutter build bundle -v > "$third_build_log" 2>&1
+if ! grep -q "build_hooks: Starting due to" "$third_build_log"; then
+  echo "Expected editing a transitive #include to rerun build_hooks." >&2
+  cat "$third_build_log" >&2
+  exit 1
+fi
+
+if [[ ! -s "$bundle" ]]; then
+  echo "Expected shader bundle at $bundle after rebuild" >&2
+  exit 1
+fi

--- a/tool/verify_shader_bundle_hook.sh
+++ b/tool/verify_shader_bundle_hook.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fixture_source="$repo_root/test_fixtures/shader_bundle_app"
+verify_build_hook_cache="${VERIFY_BUILD_HOOK_CACHE:-false}"
+verify_direct_shader="${VERIFY_DIRECT_SHADER:-false}"
 verify_transitive_include="${VERIFY_TRANSITIVE_INCLUDE:-false}"
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
@@ -28,12 +30,20 @@ if [[ ! -s "$bundle" ]]; then
   exit 1
 fi
 
+if [[ "$verify_build_hook_cache" != "true" ]]; then
+  exit 0
+fi
+
 second_build_log="$workdir/second_build.log"
 flutter build bundle -v > "$second_build_log" 2>&1
 if ! grep -q "Skipping target: build_hooks" "$second_build_log"; then
   echo "Expected unchanged build to skip build_hooks." >&2
   cat "$second_build_log" >&2
   exit 1
+fi
+
+if [[ "$verify_direct_shader" != "true" ]]; then
+  exit 0
 fi
 
 cat > shaders/smoke.frag <<'GLSL'

--- a/tool/verify_shader_bundle_hook.sh
+++ b/tool/verify_shader_bundle_hook.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fixture_source="$repo_root/test_fixtures/shader_bundle_app"
+verify_transitive_include="${VERIFY_TRANSITIVE_INCLUDE:-false}"
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
@@ -35,21 +36,50 @@ if ! grep -q "Skipping target: build_hooks" "$second_build_log"; then
   exit 1
 fi
 
-cat > shaders/shared_color.glsl <<'GLSL'
-vec4 sharedColor() {
-  return vec4(0.9, 0.8, 0.7, 1.0);
+cat > shaders/smoke.frag <<'GLSL'
+#version 460 core
+
+#include <shared_color.glsl>
+
+out vec4 frag_color;
+
+void main() {
+  frag_color = vec4(0.4, 0.5, 0.6, 1.0);
 }
 GLSL
 
 third_build_log="$workdir/third_build.log"
 flutter build bundle -v > "$third_build_log" 2>&1
 if ! grep -q "build_hooks: Starting due to" "$third_build_log"; then
-  echo "Expected editing a transitive #include to rerun build_hooks." >&2
+  echo "Expected editing a directly declared shader to rerun build_hooks." >&2
   cat "$third_build_log" >&2
   exit 1
 fi
 
 if [[ ! -s "$bundle" ]]; then
-  echo "Expected shader bundle at $bundle after rebuild" >&2
+  echo "Expected shader bundle at $bundle after direct shader rebuild" >&2
+  exit 1
+fi
+
+if [[ "$verify_transitive_include" != "true" ]]; then
+  exit 0
+fi
+
+cat > shaders/shared_color.glsl <<'GLSL'
+vec4 sharedColor() {
+  return vec4(0.9, 0.8, 0.7, 1.0);
+}
+GLSL
+
+fourth_build_log="$workdir/fourth_build.log"
+flutter build bundle -v > "$fourth_build_log" 2>&1
+if ! grep -q "build_hooks: Starting due to" "$fourth_build_log"; then
+  echo "Expected editing a transitive #include to rerun build_hooks." >&2
+  cat "$fourth_build_log" >&2
+  exit 1
+fi
+
+if [[ ! -s "$bundle" ]]; then
+  echo "Expected shader bundle at $bundle after transitive include rebuild" >&2
   exit 1
 fi


### PR DESCRIPTION
- add a fixture Flutter app that uses a real hook/build.dart and shader bundle manifest
- add tool/verify_shader_bundle_hook.sh to build the fixture, verify bundle output, verify unchanged builds skip build_hooks, and verify shader edits rerun build_hooks
- add dedicated GitHub Actions PR shards for Flutter master and Flutter stable
- keep the master shard checking transitive #include invalidation via depfile support, while the stable shard checks the backwards-compatible direct shader dependency path