### PR TITLE
Prepare 0.4.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.4.5
 
 * Added optional Dart DataAssets registration for shader bundles via
   `ShaderBundleAssetMode`. The default remains legacy file output under

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gpu_shaders
 description: 'Build tools for Flutter GPU shader bundles/libraries.'
-version: 0.4.4
+version: 0.4.5
 homepage: https://github.com/bdero/flutter_gpu_shaders
 
 environment:


### PR DESCRIPTION
- bump `flutter_gpu_shaders` to 0.4.5
- finalize the changelog entry for the DataAssets shader bundle mode

## Tests
- `flutter analyze`
- `flutter test`
- `flutter pub publish --dry-run`